### PR TITLE
Feat/global cohorts feature sync - based on PR by Rich

### DIFF
--- a/js/components/security/access/configure-access-modal.html
+++ b/js/components/security/access/configure-access-modal.html
@@ -106,9 +106,9 @@
 				      " 
 			   class="btn btn-primary",		   
 		    />
-		</div>
-		
-	    </div>    
+		</div>	
+	    </div>
+
 	    <div><br></div>
 	    
         </div>

--- a/js/components/security/access/configure-access-modal.html
+++ b/js/components/security/access/configure-access-modal.html
@@ -87,7 +87,7 @@
 
 	    
 	    <div><br></div>
-	    <!-- TODO: WORKING ON ADDING A BUTTON TO SHARE GLOBALLY -->
+	    <!-- A BUTTON TO SHARE GLOBALLY -->
 	    <div>
 		<label data-bind="css: classes('new-access-label'), text: ko.i18n('common.configureAccessModal.globalReadStatus', 'Status of global READ access:')"></label>
 		<div/>

--- a/js/components/security/access/configure-access-modal.html
+++ b/js/components/security/access/configure-access-modal.html
@@ -14,13 +14,18 @@
 										    readRoleOptions: readRoleOptions,
 										    readRoleSearch: readRoleSearch,
 		                                                                    writeRoleOptions: writeRoleOptions,
-										    writeRoleSearch: writeRoleSearch
+										    writeRoleSearch: writeRoleSearch,
+                                                                                    shareFlag: shareFlag,
+		                                                                    grantGlobalReadAccess: grantGlobalReadAccess,
+                                                                                    revokeGlobalReadAccess: revokeGlobalReadAccess,
 										 }">
     <loading data-bind="css: classes('loading-panel'), visible: isLoading()" params="status: ko.i18n('common.configureAccessModal.loadingAccessList', 'Loading access list...')"></loading>
+
+    
     <div data-bind="css: classes()">
         <div data-bind="if: !isLoading()">
             <div data-bind="css: classes('new-access')">
-                <label data-bind="css: classes('new-access-label'), text: ko.i18n('common.configureAccessModal.addWriteAccessToRole', 'Add WRITE access to role:')"></label>
+                <label data-bind="css: classes('new-access-label'), text: ko.i18n('common.configureAccessModal.addWriteAccessToRole', 'Grant WRITE access to role:')"></label>
                 <div class="input-group"
                      data-bind="css: classes({ element: 'new-access-btn-group', extra: ['new-access-btn-group'] })">
                     <input
@@ -48,8 +53,10 @@
                     </div>
                 </div>
 	    </div>
+
+	    <div>	   	
 	    <div data-bind="css: classes('new-access')">
-		<label data-bind="css: classes('new-access-label'), text: ko.i18n('common.configureAccessModal.addReadAccessToRole', 'Add READ access to role:')"></label>
+		<label data-bind="css: classes('new-access-label'), text: ko.i18n('common.configureAccessModal.addReadAccessToRole', 'Grant READ access to role:')"></label>
                 <div class="input-group"
                      data-bind="css: classes({ element: 'new-access-btn-group', extra: ['new-access-btn-group'] })">
                     <input
@@ -77,6 +84,33 @@
                     </div>
 		</div>
 	    </div>
+
+	    
+	    <div><br></div>
+	    <!-- TODO: WORKING ON ADDING A BUTTON TO SHARE GLOBALLY -->
+	    <div>
+		<label data-bind="css: classes('new-access-label'), text: ko.i18n('common.configureAccessModal.globalReadStatus', 'Status of global READ access:')"></label>
+		<div/>
+		<div class="btn-group" data-toggle="buttons">
+		    <label data-bind="css: { active: shareFlag() },
+				      click: function () { shareFlag(true); revokeGlobalReadAccess();},
+				      clickBubble: false,
+				      text: ko.i18n('common.configureAccessModal.globalReadStatusNotGranted', 'Not Granted')
+				      "
+			   class="btn btn-primary",		   
+		    />
+		    <label data-bind="css: { active: !shareFlag() }, 
+				      click: function () { shareFlag(false); grantGlobalReadAccess();},
+				      clickBubble: false,
+				      text: ko.i18n('common.configureAccessModal.globalReadStatusIsGranted', 'Granted')
+				      " 
+			   class="btn btn-primary",		   
+		    />
+		</div>
+		
+	    </div>    
+	    <div><br></div>
+	    
         </div>
     </div>
 </atlas-modal>

--- a/js/components/security/access/configure-access-modal.js
+++ b/js/components/security/access/configure-access-modal.js
@@ -111,7 +111,14 @@ define([
 			} catch (ex) {
 				console.log(ex);
 			}
-			this.isLoading(false);
+		       this.isLoading(false);
+
+		       // update shareFlag depending on if the shared artifacts reader role is in readAccessList
+		       function testForGlobalRead(value, index, array) {
+			   return value.id === 16;
+		       }
+		       let tst = this.readAccessList().some(testForGlobalRead);
+		       this.shareFlag(tst);
 		}
 
 		async grantAccess(perm_type) {
@@ -149,8 +156,8 @@ define([
 		    this.isLoading(true);
 		    try {
 			console.log('grantGlobalReadAccess  function  called to grant read permissions!! shareflag: ' + this.shareFlag());
-			await this.grantAccessFn('1006','READ'); // temporarily 1006 is 'shared artifacts reader'
-			await this._loadReadAccessList();
+			await this.grantAccessFn('16','READ'); // 16 is 'shared artifacts reader', a SYSTEM role every user should have
+			await this.loadAccessList();
 		    } catch (ex) {
 			console.log(ex);
 		    }
@@ -161,7 +168,7 @@ define([
 		    this.isLoading(true);
 		    try {
 			console.log('revokeGlobalReadAccess  function  called to REVOKE read permissions!! shareflag: ' + this.shareFlag());
-			await this.revokeAccessFn('1006','READ'); // temporarily 1006 is 'shared artifacts reader'
+			await this.revokeAccessFn('16','READ'); // 16 is 'shared artifacts reader', a SYSTEM role every user should have
 			await this.loadAccessList();
 		    } catch (ex) {
 			console.log(ex);

--- a/js/components/security/access/configure-access-modal.js
+++ b/js/components/security/access/configure-access-modal.js
@@ -33,7 +33,9 @@ define([
 			this.readRoleOptions = ko.computed(() => this.readRoleSuggestions().map(r => r.name));
 			this.readRoleSearch = ko.observable();
 			this.readRoleSearch.subscribe(str => this.loadReadRoleSuggestions(str));
-
+		    
+		        this.shareFlag = ko.observable(true);
+		    
 			this.isOwnerFn = params.isOwnerFn;
 			this.grantAccessFn = params.grantAccessFn;
 			this.loadAccessListFn = params.loadAccessListFn;
@@ -124,7 +126,6 @@ define([
 				   const role = this.readRoleSuggestions().find(r => r.name === this.readRoleName());
 			   	   await this.grantAccessFn(role.id,'READ');
 				   await this._loadReadAccessList();
-				   this.readRoleName('');
 			       }
 			} catch (ex) {
 				console.log(ex);
@@ -141,6 +142,31 @@ define([
 				console.log(ex);
 			}
 			this.isLoading(false);
+		}
+
+
+  	        async grantGlobalReadAccess() {
+		    this.isLoading(true);
+		    try {
+			console.log('grantGlobalReadAccess  function  called to grant read permissions!! shareflag: ' + this.shareFlag());
+			await this.grantAccessFn('1006','READ'); // temporarily 1006 is 'shared artifacts reader'
+			await this._loadReadAccessList();
+		    } catch (ex) {
+			console.log(ex);
+		    }
+		    this.isLoading(false);
+		}
+
+  	        async revokeGlobalReadAccess() {	    
+		    this.isLoading(true);
+		    try {
+			console.log('revokeGlobalReadAccess  function  called to REVOKE read permissions!! shareflag: ' + this.shareFlag());
+			await this.revokeAccessFn('1006','READ'); // temporarily 1006 is 'shared artifacts reader'
+			await this.loadAccessList();
+		    } catch (ex) {
+			console.log(ex);
+		    }
+		    this.isLoading(false);
 		}
 	}
 

--- a/js/components/security/access/configure-access-modal.js
+++ b/js/components/security/access/configure-access-modal.js
@@ -115,7 +115,7 @@ define([
 
 		       // update shareFlag depending on if the shared artifacts reader role is in readAccessList
 		       function testForGlobalRead(value, index, array) {
-			   return value.id === 16;
+			   return value.id === 1; // the 'public' role that every use should have
 		       }
 		       let tst = this.readAccessList().some(testForGlobalRead);
 		       this.shareFlag(tst);
@@ -156,7 +156,7 @@ define([
 		    this.isLoading(true);
 		    try {
 			console.log('grantGlobalReadAccess  function  called to grant read permissions!! shareflag: ' + this.shareFlag());
-			await this.grantAccessFn('16','READ'); // 16 is 'shared artifacts reader', a SYSTEM role every user should have
+			await this.grantAccessFn('1','READ'); // 16 is the 'public' role, a SYSTEM role every user should have
 			await this.loadAccessList();
 		    } catch (ex) {
 			console.log(ex);
@@ -168,7 +168,7 @@ define([
 		    this.isLoading(true);
 		    try {
 			console.log('revokeGlobalReadAccess  function  called to REVOKE read permissions!! shareflag: ' + this.shareFlag());
-			await this.revokeAccessFn('16','READ'); // 16 is 'shared artifacts reader', a SYSTEM role every user should have
+			await this.revokeAccessFn('1','READ'); // 16 is the 'public' role, a SYSTEM role every user should have
 			await this.loadAccessList();
 		    } catch (ex) {
 			console.log(ex);

--- a/js/components/security/access/configure-access-modal.js
+++ b/js/components/security/access/configure-access-modal.js
@@ -1,6 +1,6 @@
 define([
 	'knockout',
-	'text!./configure-access-modal.html',
+        'text!./configure-access-modal.html',
 	'components/Component',
 	'utils/CommonUtils',
 	'utils/AutoBind',
@@ -8,7 +8,7 @@ define([
 	'databindings',
 ], function (
 	ko,
-	view,
+        view,
 	Component,
 	commonUtils,
 	AutoBind
@@ -33,7 +33,7 @@ define([
 			this.readRoleOptions = ko.computed(() => this.readRoleSuggestions().map(r => r.name));
 			this.readRoleSearch = ko.observable();
 			this.readRoleSearch.subscribe(str => this.loadReadRoleSuggestions(str));
-		    
+
 		        this.shareFlag = ko.observable(true);
 		    
 			this.isOwnerFn = params.isOwnerFn;

--- a/js/pages/cohort-definitions/cohort-definition-manager.html
+++ b/js/pages/cohort-definitions/cohort-definition-manager.html
@@ -76,21 +76,21 @@
 				<a data-bind="text: ko.i18n('cohortDefinitions.cohortDefinitionManager.tabs.generation', 'Generation')"></a>
 			</li>
 
-			<!-- <li role="presentation"
-			     data-bind="visible: !previewVersion(), css: { active: $component.tabMode() == 'samples' }, click: clickSampleTab">
-			     <a data-bind="text: ko.i18n('cohortDefinitions.cohortDefinitionManager.tabs.samples', 'Samples')"></a>
-			     </li> -->
+			<li role="presentation"
+			    data-bind="visible: !previewVersion(), css: { active: $component.tabMode() == 'samples' }, click: clickSampleTab">
+			    <a data-bind="text: ko.i18n('cohortDefinitions.cohortDefinitionManager.tabs.samples', 'Samples')"></a>
+			</li>
 
 			<li role="presentation"
 				data-bind="visible: !previewVersion(), css: { active: $component.tabMode() == 'reporting' }, click: function() { $component.selectTab('reporting'); }">
 				<a data-bind="text: ko.i18n('cohortDefinitions.cohortDefinitionManager.tabs.reporting', 'Reporting')"></a>
 			</li>
-			<!--
+			
 			<li role="presentation"
-				data-bind="visible: !previewVersion(), css: { active: $component.tabMode() == 'explore' }, click: function() { $component.selectTab('explore'); }">
-				<a data-bind="text: ko.i18n('cohortDefinitions.cohortDefinitionManager.tabs.explore', 'Explore')"></a>
+				  data-bind="visible: !previewVersion(), css: { active: $component.tabMode() == 'explore' }, click: function() { $component.selectTab('explore'); }">
+			    <a data-bind="text: ko.i18n('cohortDefinitions.cohortDefinitionManager.tabs.explore', 'Explore')"></a>
 			</li>
-			-->
+			
 			<li role="presentation"
 				data-bind="visible: !previewVersion(), css: { active: $component.tabMode() == 'export' }, click: () => { $component.selectTab('export'); refreshPrintFriendly(); }">
 				<a data-bind="text: ko.i18n('cohortDefinitions.cohortDefinitionManager.tabs.export', 'Export')"></a>

--- a/js/pages/cohort-definitions/cohort-definition-manager.html
+++ b/js/pages/cohort-definitions/cohort-definition-manager.html
@@ -33,7 +33,7 @@
 					<button class="btn btn-primary"
 						data-bind="visible: !previewVersion(), title: ko.i18n('cohortDefinitions.cohortDefinitionManager.getLinkCohortTitle', 'Get a link to this cohort definition'), enable: !dirtyFlag().isDirty() && !isProcessing(), click: function () { $component.cohortLinkModalOpened(true) }"><i class="fa fa-link"></i></button>
 
-					<!-- ko if: enablePermissionManagement -->
+					<!-- ko if: (enablePermissionManagement() === true && userCanShare() === true) -->
 					<button class="btn btn-primary"
 						data-bind="title: ko.i18n('common.configureAccess', 'Configure access'), visible: isOwner() && !previewVersion(), click: () => isAccessModalShown(!isAccessModalShown())">
 						<i class="fa fa-lock"></i>
@@ -76,10 +76,10 @@
 				<a data-bind="text: ko.i18n('cohortDefinitions.cohortDefinitionManager.tabs.generation', 'Generation')"></a>
 			</li>
 
-			<li role="presentation"
-				data-bind="visible: !previewVersion(), css: { active: $component.tabMode() == 'samples' }, click: clickSampleTab">
-				<a data-bind="text: ko.i18n('cohortDefinitions.cohortDefinitionManager.tabs.samples', 'Samples')"></a>
-			</li>
+			<!-- <li role="presentation"
+			     data-bind="visible: !previewVersion(), css: { active: $component.tabMode() == 'samples' }, click: clickSampleTab">
+			     <a data-bind="text: ko.i18n('cohortDefinitions.cohortDefinitionManager.tabs.samples', 'Samples')"></a>
+			     </li> -->
 
 			<li role="presentation"
 				data-bind="visible: !previewVersion(), css: { active: $component.tabMode() == 'reporting' }, click: function() { $component.selectTab('reporting'); }">

--- a/js/pages/concept-sets/conceptset-manager.html
+++ b/js/pages/concept-sets/conceptset-manager.html
@@ -27,7 +27,7 @@
         <button type="button" class="btn btn-primary" data-bind="click: () => isTagsModalShown(!isTagsModalShown()), visible: canEdit() && !previewVersion(), css: { disabled: isProcessing() }, title: ko.i18n('common.tags', 'Tags')"><i class="fa fa-tags"></i></button>
         <button type="button" class="btn btn-primary" data-bind="visible: !previewVersion(), click: optimize, css: { disabled: !canOptimize() || isProcessing() }, text: ko.i18n('cs.manager.optimize', 'Optimize')"></button>
 
-	<!-- ko if: enablePermissionManagement -->
+	<!-- ko if: (enablePermissionManagement() === true && userCanShare() === true)  -->
         <button class="btn btn-primary" data-bind="visible: !previewVersion() && isOwner(), click: () => isAccessModalShown(!isAccessModalShown()), title: ko.i18n('common.configureAccess', 'Configure access')">
             <i class="fa fa-lock"></i>
         </button>

--- a/js/pages/concept-sets/conceptset-manager.js
+++ b/js/pages/concept-sets/conceptset-manager.js
@@ -8,7 +8,8 @@ define([
 	'./const',
 	'const',
 	'components/conceptset/utils',
-	'services/Vocabulary',
+        'services/Vocabulary',
+    	'services/ShareRoleCheck',
 	'services/Permission',
 	'services/Tags',
 	'components/security/access/const',
@@ -55,7 +56,8 @@ define([
 	constants,
 	globalConstants,
 	utils,
-	vocabularyAPI,
+        vocabularyAPI,
+        shareRoleCheck,
 	GlobalPermissionService,
 	TagsService,
 	{ entityType },
@@ -174,7 +176,25 @@ define([
 			this.canCopy = ko.computed(() => {
 				return this.currentConceptSet() && this.currentConceptSet().id > 0;
 			});
-			this.enablePermissionManagement = config.enablePermissionManagement;	    
+
+		        this.enablePermissionManagement = ko.observable(false);
+ 		        this.enablePermissionManagement(config.enablePermissionManagement);
+
+		        this.userCanShare = ko.observable(false);
+		        if (config.permissionManagementRoleId === "") {
+			   this.userCanShare(true);
+		        } else {
+			   shareRoleCheck.checkIfRoleCanShare(authApi.subject(), config.permissionManagementRoleId)
+				.then(res=>{
+				    this.userCanShare(res);
+				})
+				.catch(error => {
+				    console.error(error);
+				    alert(ko.i18n('conceptSets.conceptSetManager.shareRoleCheck', 'Error when determining if user can share cohorts')());
+				});
+			}		        
+
+		    
 			this.isSaving = ko.observable(false);
 			this.isDeleting = ko.observable(false);
 			this.isOptimizing = ko.observable(false);

--- a/js/pages/concept-sets/conceptset-manager.js
+++ b/js/pages/concept-sets/conceptset-manager.js
@@ -190,7 +190,7 @@ define([
 				})
 				.catch(error => {
 				    console.error(error);
-				    alert(ko.i18n('conceptSets.conceptSetManager.shareRoleCheck', 'Error when determining if user can share cohorts')());
+				    alert(ko.i18n('conceptSets.conceptSetManager.shareRoleCheck', 'Error when determining if user can share concept sets')());
 				});
 			}		        
 

--- a/js/services/ShareRoleCheck.js
+++ b/js/services/ShareRoleCheck.js
@@ -1,0 +1,32 @@
+define(function (require, exports) {
+    var $ = require('jquery');
+    var constants = require('const');
+    const httpService = require('services/http');
+    
+    async function getRoleUsers(subject, permissionManagementRoleId) {
+	return await httpService.doGet(constants.apiPaths.roleUsers(permissionManagementRoleId))
+	      .then(({ data = [] }) => data)
+	      .catch((er) => {
+		  console.error('ERROR: Can\'t find users with permissionManagementRoleId: ' + permissionManagementRoleId);
+	      });
+    };
+    
+    async function checkIfRoleCanShare(subject, permissionManagementRoleId) {
+	var isAbleToShare = false;
+	const roleUsers = await getRoleUsers(subject, permissionManagementRoleId);
+	console.log("INFO: roleUsers:" + roleUsers.toString());
+	
+	roleUsers.forEach((user) => {
+	    console.log("INFO: user.login of user that has the permissionManagementRoleId " + permissionManagementRoleId + ": " + user.login + "; subject (currently logged in user): " + subject);
+            if (subject == user.login){
+		isAbleToShare = true;		
+	    }
+        });
+	console.log("INFO: isAbleToShare: " + isAbleToShare);
+	return isAbleToShare;
+    };
+
+    return {
+	checkIfRoleCanShare,
+    };
+});


### PR DESCRIPTION
Pulling in changes from https://github.com/OHDSI/Atlas/pull/2929 

Link to JIRA ticket if there is one:  https://ctds-planx.atlassian.net/browse/VADC-1063

### New Features
- Global sharing feature. See https://github.com/OHDSI/Atlas/pull/2929 for detailed description, including video with an explanation.

### Deployment changes
- A new configuration item needs to be added to `js/config-local.js` (according to doc from upstream PR): 
   - `configLocal.permissionManagementRoleId`: By default set to an empty string ('') indicating that all users can share globally. Optionally, it can be set to the id of the a non-system role used to restrict the ability to share artifacts globally to a specific set of users