### PR TITLE
Fix: move isOwner() check for conceptsets

### DIFF
--- a/js/pages/concept-sets/conceptset-manager.html
+++ b/js/pages/concept-sets/conceptset-manager.html
@@ -28,7 +28,7 @@
         <button type="button" class="btn btn-primary" data-bind="visible: !previewVersion(), click: optimize, css: { disabled: !canOptimize() || isProcessing() }, text: ko.i18n('cs.manager.optimize', 'Optimize')"></button>
 
 	<!-- ko if: (enablePermissionManagement() === true && userCanShare() === true)  -->
-        <button class="btn btn-primary" data-bind="visible: !previewVersion() && isOwner(), click: () => isAccessModalShown(!isAccessModalShown()), title: ko.i18n('common.configureAccess', 'Configure access')">
+        <button class="btn btn-primary" data-bind="visible: !previewVersion(), click: () => isAccessModalShown(!isAccessModalShown()), title: ko.i18n('common.configureAccess', 'Configure access')">
             <i class="fa fa-lock"></i>
         </button>
 	<!-- /ko -->

--- a/js/pages/concept-sets/conceptset-manager.js
+++ b/js/pages/concept-sets/conceptset-manager.js
@@ -175,11 +175,21 @@ define([
 				return this.currentConceptSet() && this.currentConceptSet().id > 0;
 			});
 
+			GlobalPermissionService.decorateComponent(this, {
+				entityTypeGetter: () => entityType.CONCEPT_SET,
+				entityIdGetter: () => this.currentConceptSet() && this.currentConceptSet().id,
+				createdByUsernameGetter: () => this.currentConceptSet() && this.currentConceptSet().createdBy
+					&& this.currentConceptSet().createdBy.login
+			});
+
 			this.enablePermissionManagement = ko.observable(config.enablePermissionManagement);
 			if (config.enablePermissionManagement) {
 				this.userCanShare = ko.observable(
-						!config.limitedPermissionManagement ||
-						authApi.isPermittedGlobalShareArtifact());
+					(config.limitedPermissionManagement &&
+					 authApi.isPermittedGlobalShareArtifact()) ||
+					(!config.limitedPermissionManagement &&
+					 this.isOwner())
+				  );
 			} else {
 				this.userCanShare = ko.observable(false);
 			}
@@ -340,13 +350,6 @@ define([
 			this.selectedTab = ko.observable(0);
 
 			this.activeUtility = ko.observable("");
-
-			GlobalPermissionService.decorateComponent(this, {
-				entityTypeGetter: () => entityType.CONCEPT_SET,
-				entityIdGetter: () => this.currentConceptSet() && this.currentConceptSet().id,
-				createdByUsernameGetter: () => this.currentConceptSet() && this.currentConceptSet().createdBy
-					&& this.currentConceptSet().createdBy.login
-			});
 
 			this.tags = ko.observableArray(this.currentConceptSet() && this.currentConceptSet().tags);
 			TagsService.decorateComponent(this, {


### PR DESCRIPTION
Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/VADC-1063

### Bug Fixes
- fixes a remaining issue after https://github.com/uc-cdis/Atlas/pull/47, where the `isOwner()` check is missing for conceptset-manager

