### PR TITLE
Fix: hide menu options until user has logged in

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
 			</div>
 
 			<div class="app__menu">
+				<!-- ko if: isLoggedIn -->
 				<!-- ko foreach: router.pages -->
 				<!-- ko if: ko.unwrap($data.title) && (ko.unwrap($data.title) == 'Home' || ko.unwrap($data.title) == 'Search' || ko.unwrap($data.title) == 'Concept Sets' || ko.unwrap($data.title) == 'Cohort Definitions') --> 
 				<a data-bind="visible: !$data.hidden, attr: {href: navUrl()}, css: $parent.classes({ element: 'menu-item', modifiers: $parent.router.activeRoute().title === $data.title ? 'selected' : '', extra: statusCss() })">
@@ -48,6 +49,7 @@
 					<span data-bind="text: $data.title, css: $parent.classes('menu-title')"></span>
 				</a>
 				<!-- /ko --> 
+				<!-- /ko -->
 				<!-- /ko -->
 			</div>
 

--- a/js/Application.js
+++ b/js/Application.js
@@ -96,6 +96,7 @@ define(
 				});
 				this.companyInfoTemplate = config.companyInfoCustomHtmlTemplate;
 				this.showCompanyInfo = config.showCompanyInfo;
+				this.isLoggedIn = ko.computed(() => authApi.isAuthenticated());
 			}
 
 			/**


### PR DESCRIPTION
Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/VADC-1221

### New Features
- menu options are hidden until user has logged in. This fixes an issue related to missing "teamproject" info and subsequent (transient) login flow error and need to refresh the page