### PR TITLE
Display a warning when session expires and force refresh the page

### DIFF
--- a/js/services/AuthAPI.js
+++ b/js/services/AuthAPI.js
@@ -538,7 +538,7 @@ define(function(require, exports) {
         subject(null);
         permissions(null);
         alert("Warning: Permission is denied and session is cleared. This is possibly due to duplicate session. Please refresh page before signing in again to prevent errors.")
-        window.parent.location = document.referrer;
+        window.parent.location = document.referrer + "analysis/" ;
         window.top.location.reload();
     };
 

--- a/js/services/AuthAPI.js
+++ b/js/services/AuthAPI.js
@@ -538,7 +538,7 @@ define(function(require, exports) {
         subject(null);
         permissions(null);
         alert("Warning: Permission is denied and session is cleared. This is possibly due to duplicate session. Please refresh page before signing in again to prevent errors.")
-        window.location.reload();
+        window.top.location.reload();
     };
 
     const runAs = function(login, success, error) {

--- a/js/services/AuthAPI.js
+++ b/js/services/AuthAPI.js
@@ -537,6 +537,8 @@ define(function(require, exports) {
         token(null);
         subject(null);
         permissions(null);
+        alert("Warning: Permission is denied and session is cleared. This is possibly due to duplicate session. Please refresh page before signing in again to prevent errors.")
+        window.location.reload();
     };
 
     const runAs = function(login, success, error) {

--- a/js/services/AuthAPI.js
+++ b/js/services/AuthAPI.js
@@ -538,6 +538,7 @@ define(function(require, exports) {
         subject(null);
         permissions(null);
         alert("Warning: Permission is denied and session is cleared. This is possibly due to duplicate session. Please refresh page before signing in again to prevent errors.")
+        window.parent.location = document.referrer;
         window.top.location.reload();
     };
 


### PR DESCRIPTION
https://ctds-planx.atlassian.net/browse/VADC-1600

- Describe what this pull request does.
When user attempt to access Atlas through multiple sessions, previous session will time out. If they sign in again, potentially the team project used by Atlas could go out of sync.

This PR implements a feature that display an alert when it detects session is cleared, and refresh the entire page.

<img width="1700" alt="Screenshot 2025-02-20 at 4 20 13 PM" src="https://github.com/user-attachments/assets/83337ac4-a4bd-4bd3-a463-cd32958c4ee0" />

### Improvements
Add alert for session clear and force refresh the page
